### PR TITLE
PDE-3204 removed prod database flag

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "2.0"
 description: A Helm chart for Kubernetes
 name: service
-version: 0.2.1
+version: 1.2.1

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -25,9 +25,6 @@ spec:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
-        {{ if ne $environment "production" }}
-        {{ include "service.database"  . | indent 8 }}
-        {{ end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
+        {{ include "service.database"  . | indent 8 }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}


### PR DESCRIPTION
Removed the template `if` for not including the database in production. This was originally added to allow for the database connection string to be passed outside of the helm chart, but the database will be independent of the environment and decided by the inclusion of a database configuration in the values.yml files.