### PR TITLE
added support for forwardOriginalToken

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.2.4
+version: 1.2.5
 
 

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.2.3
+version: 1.2.4
 
 

--- a/charts/service/templates/istio-policy.yaml
+++ b/charts/service/templates/istio-policy.yaml
@@ -13,6 +13,7 @@ spec:
   jwtRules:
   - issuer: {{ $auth.issuer }}
     jwksUri: {{ $auth.jwks }}
+    forwardOriginalToken: {{ $auth.forwardOriginalToken }}
 
 ---
 apiVersion: security.istio.io/v1beta1

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -61,14 +61,17 @@ auth:
     enabled: true
     issuer: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7'
     jwks: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7/v1/keys'
+    forwardOriginalToken: true
   stage:
     enabled: true
     issuer: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7'
     jwks: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7/v1/keys'
+    forwardOriginalToken: true
   production:
     enabled: true
     issuer: 'https://chghealthcare.okta.com/oauth2/aus46u1vjfkkTfP7d2p7'
     jwks: 'https://chghealthcare.okta.com/oauth2/aus46u1vjfkkTfP7d2p7/v1/keys'
+    forwardOriginalToken: true
 
 
 envs: []


### PR DESCRIPTION
Currently working on Containerizing the CDP Experience API and with the help of Derek was able to get it deployed and was seeing that the Authorization header is being stripped from the request by istio looking at their docs it seems that we need to add a `forwardOriginalToken` key which is set to false by default and omits the token from the request.

istio docs where i found this: https://istio.io/docs/reference/config/security/jwt/

also not 100% sure how you do your versioning so i just incremented patch version by 1?? but i can obviously change it to what ever thanks!