### PR TITLE
Fix PVC support to handle proper affinity and scheduler

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.2.6
+version: 1.2.7
 
 
 

--- a/charts/service/templates/_affinity.tpl
+++ b/charts/service/templates/_affinity.tpl
@@ -1,0 +1,32 @@
+{{- define "service.affinity" }}
+{{- if .Values.persistentVolume }}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: px/enabled
+          operator: NotIn
+          values:
+          - "false"
+        - key: worker-type
+          operator: NotIn
+          values:
+          - jenkins-workers
+{{- else if .Values.affinity -}}
+{{- with .Values.affinity }}
+affinity:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- else }}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: worker-type
+            operator: NotIn
+            values:
+            - jenkins-workers
+{{- end }}
+{{- end }}

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
+      {{- if .Values.persistentVolume }}
+      schedulerName: stork 
+      {{- end }}
       containers:
         {{- include "service.database"  . | indent 8 }}
         - name: {{ .Chart.Name }}
@@ -85,25 +88,22 @@ spec:
               port: {{ .Values.service.target }}
             initialDelaySeconds: 20
             periodSeconds: 20
-          {{ if eq .Values.persistentVolume.attach true -}}
+          {{- if .Values.persistentVolume }}
           volumeMounts:
             - mountPath: {{ .Values.persistentVolume.mountPath }}
               name: {{ .Values.persistentVolume.volumeName }}
-          {{ end }}
-      {{- with .Values.nodeSelector }}
+          {{- end -}}
+      {{- with .Values.nodeSelector -}}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{ if eq .Values.persistentVolume.attach true -}}
+      {{- end -}}
+      {{ if .Values.persistentVolume }}
       volumes:
         - name: {{ .Values.persistentVolume.volumeName }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistentVolume.claimName }}
-      {{ end }}
-    {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end -}}
+    {{ include "service.affinity" . | indent 6 }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/service/templates/persistent-volume-claim.yaml
+++ b/charts/service/templates/persistent-volume-claim.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.persistentVolumeClaim.enabled true -}}
+{{ if .Values.persistentVolumeClaim -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -126,7 +126,7 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity:
+affinity: 
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
@@ -136,23 +136,23 @@ affinity:
           values:
           - jenkins-workers
 
-persistentVolumeClaim:
+persistentVolumeClaim: {}
   # This should only be used if a claim does not already exist.  If there is a pre-existing 
   # claim (e.g. an existing shared volume), you need only attach a persistentVolume (below)
   # and reference the name of the existing claim.
-  enabled: false 
+  # enabled: false 
   # size: 2Gi
   # name: px-test-shared
-  type: shared # Valid options: shared, secure, postgres
-  mode: ReadWriteMany # IMPORTANT: for any type other than "shared" the mode should be set to ReadWriteOnce
+  # type: shared # Valid options: shared, secure, postgres
+  # mode: ReadWriteMany # IMPORTANT: for any type other than "shared" the mode should be set to ReadWriteOnce
 
-persistentVolume:
+persistentVolume: {}
   # Mount a volume from a persistentVolumeClaim.  If not using a pre-existing claim, you must
   # also enable a new persistentVolumeClaim (above) and reference it by name (claimName) here
-  attach: false
+  # attach: false
   # claimName: px-text-shared
-  volumeName: data
-  mountPath: /data
+  # volumeName: data
+  # mountPath: /data
 
 scaling:
   minReplicas: 2


### PR DESCRIPTION
PVC support requires specific node affinity and a specific scheduler.  This adds a helper to inject the right affinity depending on specific values provided.