### PR TITLE
parameterize documentation path when it is not '/docs' or '/docs/*'

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.3.1
+version: 1.3.3

--- a/charts/service/templates/istio-policy.yaml
+++ b/charts/service/templates/istio-policy.yaml
@@ -35,6 +35,6 @@ spec:
   - to:
     - operation:
         methods: ["GET"]
-        paths: ["/liveness", "/readiness", "{{ .Values.health.path }}", "/", "/docs", "/docs/*", "{{ .Values.api_doc_path }}"]
+        paths: ["/liveness", "/readiness", "{{ .Values.health.path }}", "/", "/docs", "/docs/*", "/swagger-ui/*"]
 
 {{- end -}}

--- a/charts/service/templates/istio-policy.yaml
+++ b/charts/service/templates/istio-policy.yaml
@@ -35,6 +35,6 @@ spec:
   - to:
     - operation:
         methods: ["GET"]
-        paths: ["/liveness", "/readiness", "{{ .Values.health.path }}", "/", "/docs", "/docs/*"]
+        paths: ["/liveness", "/readiness", "{{ .Values.health.path }}", "/", "/docs", "/docs/*", "{{ .Values.api_doc_path }}"]
 
 {{- end -}}

--- a/charts/service/templates/istio-policy.yaml
+++ b/charts/service/templates/istio-policy.yaml
@@ -48,4 +48,5 @@ spec:
         - "/swagger-ui/*"
         {{ range .Values.istioAllowedPaths }}
         - {{ . | quote }}{{ end }}
+
 {{- end -}}


### PR DESCRIPTION
This is to accommodate Java/SpringBoot Swagger documentation which will use a path of '/swagger-ui/' and not '/docs' or '/docs/*'.  