### PR TITLE
feature: added the tolerations template 

### DIFF
--- a/charts/service/templates/_affinity.tpl
+++ b/charts/service/templates/_affinity.tpl
@@ -1,5 +1,5 @@
 {{- define "service.affinity" }}
-{{- if .Values.persistentVolume }}
+{{- if or .Values.persistentVolume .Values.persistentVolumeClaim }}
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
@@ -9,10 +9,16 @@ affinity:
           operator: NotIn
           values:
           - "false"
-        - key: worker-type
-          operator: NotIn
+{{- else if (eq .Values.environment "stage") }}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: dedicated
+          operator: In
           values:
-          - jenkins-workers
+          - "stage"
 {{- else if .Values.affinity -}}
 {{- with .Values.affinity }}
 affinity:

--- a/charts/service/templates/_tolerations.tbl
+++ b/charts/service/templates/_tolerations.tbl
@@ -1,0 +1,19 @@
+{{- define "service.tolerations" }}
+{{- if or .Values.persistentVolume .Values.persistentVolumeClaim }}
+tolerations:
+- key: "portworx"
+  operator: "Exists"
+  effect: "NoSchedule"
+{{- else if (eq .Values.environment "stage") }}
+tolerations:
+- key: "dedicated"
+  operator: "Equal"
+  value: "stage"
+  effect: "NoSchedule"
+{{- else if .Values.tolerations }}
+{{- with .Values.tolerations }}
+tolerations:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -111,7 +111,5 @@ spec:
             claimName: {{ .Values.persistentVolume.claimName }}
       {{- end -}}
     {{ include "service.affinity" . | indent 6 }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+    {{ include "service.tolerations" . | indent 6 }}
+


### PR DESCRIPTION
- updated the logic for setting the node affinity and added logic to set the tolerations based off if a PVC is required or the env is stage.  I have just tested this through helm template but not against common-nonprod k8s cluster yet. Will be doing that with help from a SA before merging this :-) 