### PR TITLE
Remove health path default

### DIFF
--- a/charts/service/templates/_probes.tpl
+++ b/charts/service/templates/_probes.tpl
@@ -2,7 +2,7 @@
 {{- define "service.probes" }}
 livenessProbe:
   httpGet:
-    {{- if .Values.health.path }}
+  {{- if .Values.health.path }}
     path: {{ .Values.health.path | quote }}
     port: {{ .Values.service.target }}
   initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
@@ -15,7 +15,7 @@ livenessProbe:
   {{- end }}
 readinessProbe:
   httpGet:
-    {{- if .Values.health.path }}
+  {{- if .Values.health.path }}
     path: {{ .Values.health.path | quote }}
     port: {{ .Values.service.target }}
   initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -55,7 +55,6 @@ service:
 #   health.periodSeconds
 # Instead, please use the health.liveness and health.readiness specific properties
 health:
-  path: '/health'
   initialDelaySeconds: 20
   periodSeconds: 20
   liveness:


### PR DESCRIPTION
I'm not going to up the version on this one.  We'll consider it a patch to 1.3.17.  This will make it so if health.path exists in the values, it will use that; otherwise it will expect liveness and readiness paths.