### PR TITLE
Feature/pde 3380 specify job retry

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.4
+version: 1.4.5

--- a/charts/service/templates/job.yaml
+++ b/charts/service/templates/job.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
   {{ end }}
 spec:
-  backoffLimit: {{ if $job.backoffLimit }}{{ $job.backoffLimit }}{{ else }}{{ 4 }}{{ end }}
+  backoffLimit: {{ $job.backoffLimit }}
   template:
     metadata:
       annotations:

--- a/charts/service/templates/job.yaml
+++ b/charts/service/templates/job.yaml
@@ -18,6 +18,7 @@ metadata:
     {{- end }}
   {{ end }}
 spec:
+  backoffLimit: {{ if $job.backoffLimit }}{{ $job.backoffLimit }}{{ else }}{{ 4 }}{{ end }}
   template:
     metadata:
       annotations:
@@ -69,6 +70,5 @@ spec:
                 name: {{ . | quote }}
           {{- end }}
       restartPolicy: Never
-  backoffLimit: 4
 
 {{ end }}

--- a/charts/service/templates/job.yaml
+++ b/charts/service/templates/job.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- end }}
   {{ end }}
 spec:
-  backoffLimit: {{ $job.backoffLimit }}
+  backoffLimit: {{ $job.backoffLimit | default 4 }}
   template:
     metadata:
       annotations:

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -227,7 +227,8 @@ cleanUpIn: 48h
 # More information here: https://kubernetes.io/docs/concepts/workloads/controllers/job/
 # jobs:
 #   - containerName: 'some-job'
-#     # number of retries. Default: 6
+#     # number of retries. Default: 4
+#     # if you want a backoffLimit of 0, it must be quoted.
 #     backoffLimit: 4
 #     image: 'node:12'
 #     command: ['echo', 'foobar']

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -225,16 +225,18 @@ cleanUpIn: 48h
 
 # For creating a Job to run with your service.
 # More information here: https://kubernetes.io/docs/concepts/workloads/controllers/job/
-#jobs:
-#- containerName: 'some-job'
-#  image: 'node:12'
-#  command: ['echo', 'foobar']
-#  annotations:
-#    "helm.sh/hook": pre-install,pre-upgrade
-#    "helm.sh/hook-delete-policy": hook-succeeded
-#  envs:
-#  - name: NODE_ENV
-#    value: development
+# jobs:
+#   - containerName: 'some-job'
+#     # number of retries. Default: 4
+#     backoffLimit: 4
+#     image: 'node:12'
+#     command: ['echo', 'foobar']
+#     annotations:
+#       "helm.sh/hook": pre-install,pre-upgrade
+#       "helm.sh/hook-delete-policy": hook-succeeded
+#     envs:
+#     - name: NODE_ENV
+#       value: development
 
 
 # Spin up a redis cluster for your service to talk to, an environment variable REDIS_HOST will be set for your service to connect to the cluster with

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -227,7 +227,7 @@ cleanUpIn: 48h
 # More information here: https://kubernetes.io/docs/concepts/workloads/controllers/job/
 # jobs:
 #   - containerName: 'some-job'
-#     # number of retries. Default: 4
+#     # number of retries. Default: 6
 #     backoffLimit: 4
 #     image: 'node:12'
 #     command: ['echo', 'foobar']


### PR DESCRIPTION
Added the ability to specify retry policy for jobs.

Example of use:
```
jobs:
  - containerName: 'chg-work-schedule-service-api-tests'
    backoffLimit: '0'
    command: ['npm', 'run', 'test:api']
    annotations:
      "helm.sh/hook": post-upgrade
      "helm.sh/hook-delete-policy": before-hook-creation
```