### PR TITLE
adding auth global config so that all services can use default

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.6
+version: 1.4.7

--- a/charts/service/templates/istio-policy.yaml
+++ b/charts/service/templates/istio-policy.yaml
@@ -1,5 +1,6 @@
 {{- $auth := pluck .Values.environment .Values.auth | first | default .Values.auth._default -}}
-{{ if eq $auth.enabled true -}}
+{{- $authGlobal := pluck .Values.environment .Values.authGlobal | first | default .Values.authGlobal._default -}}
+{{ if or (eq $auth.enabled true) (eq .Values.authEnabled true) -}}
 ---
 apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication
@@ -20,6 +21,9 @@ spec:
   - issuer: {{ $auth.issuer }}
     jwksUri: {{ $auth.jwks }}
     forwardOriginalToken: {{ $auth.forwardOriginalToken }}
+  - issuer: {{$authGlobal.issuer}}
+    jwksUri: {{ $authGlobal.jwks }}
+    forwardOriginalToken: true
 
 ---
 apiVersion: security.istio.io/v1beta1

--- a/charts/service/templates/istio-policy.yaml
+++ b/charts/service/templates/istio-policy.yaml
@@ -39,7 +39,7 @@ spec:
   rules:
   - from:
     - source:
-        requestPrincipals: ["{{ $auth.issuer }}/*"]
+        requestPrincipals: ["{{ $auth.issuer }}/*","{{ $authGlobal.issuer }}/*"]
     - source:
         namespaces: ["{{ .Release.Namespace }}"]
   - to:

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -144,10 +144,6 @@ authGlobal:
     issuer: 'https://chghealthcare.okta.com/oauth2/default'
     jwks: 'https://chghealthcare.okta.com/oauth2/default/v1/keys'
 
-public:
-  - pub
-  - public
-
 envs: []
 # - name: ENVIRONMENT
 #   value: production

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -18,7 +18,7 @@ fullnameOverride: ''
 # [REQUIRED]
 # This is a required field
 # options [development, stage, production]
-environment: 'production'
+environment: 'development'
 
 # Database Type. Default to no database.
 #
@@ -109,7 +109,9 @@ istioAllowedMethods: []
 #  numberOfInstances: 2 # number of postgres instances 1 - master 2..replica
 
 
-# The default values here are:
+
+# The default values here are: 
+authEnabled: false
 auth:
   _default:
     enabled: true
@@ -127,6 +129,24 @@ auth:
     jwks: 'https://chghealthcare.okta.com/oauth2/aus46u1vjfkkTfP7d2p7/v1/keys'
     forwardOriginalToken: true
 
+# The authGlobal values are more constant than regular authorizors. Please overide 
+# the other values first before considering changing the globals. Ultimate goal
+# is to remove the first set of values from charts all together. and utalize the
+# authEnabled flag and the global authorizors.
+authGlobal:
+  _default:
+    issuer: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7'
+    jwks: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7/v1/keys'
+  stage:
+    issuer: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7'
+    jwks: 'https://chghealthcare.oktapreview.com/oauth2/auskmtjacfEi8ffM60h7/v1/keys'
+  production:
+    issuer: 'https://chghealthcare.okta.com/oauth2/default'
+    jwks: 'https://chghealthcare.okta.com/oauth2/default/v1/keys'
+
+public:
+  - pub
+  - public
 
 envs: []
 # - name: ENVIRONMENT


### PR DESCRIPTION
Allow multiple authorizers per service. This should make so that in prod, any service that has a custom authorizer will also accept the Default authorizer. So JWTS that created by any client consuming the default authorizer can access those services. 

This also introduces the `authEnabled` flag, which once we have everyone consuming the default authorizer all that should be needed in the helm values is the `authEnabled` flag, and the regular routes that exist today. I put it with an or condition in the helm chart so it should be non breaking to existing services that are using their own `auth:` values in the helm values.

Another thing that might be worth doing in the future is switching stage env to point to Prod Okta. to make it a more prod like environment to test out services.