### PR TITLE
Bugfix/postgres db node affinity block

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.7
+version: 1.4.8

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
           {{- if .Values.postgres }}
             - name: POSTGRES_URL
               value: {{ if $root.Values.feature }}{{ printf "%s-%s-%s.%s-database" .Values.postgres.teamId $root.Values.feature .Values.postgres.dbName .Release.Namespace }}{{ else }}{{ printf "%s-%s.%s-database" .Values.postgres.teamId .Values.postgres.dbName .Release.Namespace }}{{ end }}
+            - name: POSTGRES_REPL_URL
+              value: {{ if $root.Values.feature }}{{ printf "%s-%s-%s-repl.%s-database" .Values.postgres.teamId $root.Values.feature .Values.postgres.dbName .Release.Namespace }}{{ else }}{{ printf "%s-%s-repl.%s-database" .Values.postgres.teamId .Values.postgres.dbName .Release.Namespace }}{{ end }}
             - name: POSTGRES_PORT
               value: "5432"
             - name: POSTGRES_DBNAME

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -43,13 +43,13 @@ spec:
     version: {{ quote .Values.postgres.version }}
 
   nodeAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-    nodeSelectorTerms:
-      - matchExpressions:
-          - key: px/enabled
-            operator: NotIn
-            values:
-              - "false"
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: px/enabled
+              operator: NotIn
+              values:
+                - "false"
 
 
 # Replicated Secret from the {Database Namespace}/{dbOwner Secret}


### PR DESCRIPTION
- The nodeAffinity block was incorrectly indented.  Since we set the scheduleName to stork this has not been an issue but we will want to fix this going forward.
- When teams move to this version it will just cause any current running postgresql statefulsets to be updated and a re-deploy of the pod(s) will occur.. It will use any existing PVC etc..  so there is no data loss.  This will just insure that the PODs are being scheduled on the correct nodes.