### PR TITLE
This will allow custom Postgres environment variables names

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.9
+version: 1.4.11

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.8
+version: 1.4.9

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -69,20 +69,20 @@ spec:
                     key: {{ .key | quote }}
           {{- end }}
           {{- if .Values.postgres }}
-            - name: POSTGRES_URL
+            - name: {{ if .Values.postgres.envUrlName }}{{ printf "%s" .Values.postgres.envUrlName }}{{ else }}{{ printf "POSTGRES_URL" }}{{ end }}
               value: {{ if $root.Values.feature }}{{ printf "%s-%s-%s.%s-database" .Values.postgres.teamId $root.Values.feature .Values.postgres.dbName .Release.Namespace }}{{ else }}{{ printf "%s-%s.%s-database" .Values.postgres.teamId .Values.postgres.dbName .Release.Namespace }}{{ end }}
-            - name: POSTGRES_REPL_URL
+            - name: {{ if .Values.postgres.envReplUrl }}{{ printf "%s" .Values.postgres.envReplUrl }}{{ else }}{{ printf "POSTGRES_REPL_URL" }}{{ end }}
               value: {{ if $root.Values.feature }}{{ printf "%s-%s-%s-repl.%s-database" .Values.postgres.teamId $root.Values.feature .Values.postgres.dbName .Release.Namespace }}{{ else }}{{ printf "%s-%s-repl.%s-database" .Values.postgres.teamId .Values.postgres.dbName .Release.Namespace }}{{ end }}
-            - name: POSTGRES_PORT
+            - name: {{ if .Values.postgres.envPortName }}{{ printf "%s" .Values.postgres.envPortName }}{{ else }}{{ printf "POSTGRES_PORT" }}{{ end }}
               value: "5432"
-            - name: POSTGRES_DBNAME
+            - name: {{ if .Values.postgres.envDbName }}{{ printf "%s" .Values.postgres.envDbName }}{{ else }}{{ printf "POSTGRES_DBNAME" }}{{ end }}
               value:  {{ quote .Values.postgres.dbName }}
-            - name: POSTGRES_USERNAME
+            - name: {{ if .Values.postgres.envUserName }}{{ printf "%s" .Values.postgres.envUserName }}{{ else }}{{ printf "POSTGRES_USERNAME" }}{{ end }}
               valueFrom:
                 secretKeyRef:
                     name: {{ if $root.Values.feature }}{{ printf "%s.%s-%s-%s" .Values.postgres.owner .Values.postgres.teamId $root.Values.feature .Values.postgres.dbName }}{{ else }}{{ printf "%s.%s-%s" .Values.postgres.owner .Values.postgres.teamId .Values.postgres.dbName }}{{ end }}
                     key: username
-            - name: POSTGRES_PASSWORD
+            - name: {{ if .Values.postgres.envPasswordName }}{{ printf "%s" .Values.postgres.envPasswordName }}{{ else }}{{ printf "POSTGRES_PASSWORD" }}{{ end }}
               valueFrom:
                 secretKeyRef:
                     name: {{ if $root.Values.feature }} {{ printf "%s.%s-%s-%s" .Values.postgres.owner .Values.postgres.teamId $root.Values.feature .Values.postgres.dbName }}{{ else }}{{ printf "%s.%s-%s" .Values.postgres.owner .Values.postgres.teamId .Values.postgres.dbName }}{{ end }}


### PR DESCRIPTION
This change will allow to create custom environment variable names for PostgreSql connection.  The following is an example of the environment variables names generated for Pact broker.

------------
Dry run 1: With custom environment name example
------------

Example input: 

```
postgres:
  teamId: sateam
  dbName: pactcontracts
  owner: sateam
  version: 11  # database version
  size: 2Gi   # database size
  numberOfInstances: 1
  envUrlName: PACT_BROKER_DATABASE_HOST
  envPortName: PACT_BROKER_DATABASE_PORT
  envDbName: PACT_BROKER_DATABASE_NAME
  envUserName: PACT_BROKER_DATABASE_USERNAME
  envPasswordName: PACT_BROKER_DATABASE_PASSWORD
  envReplUrl: PACT_BROKER_REPL_URL

```

This is the output for the above input:

```
  env:
            - name: "PACT_BROKER_PORT"
              value: "9292"
            - name: "PACT_BROKER_PUBLIC_HEARTBEAT"
              value: "true"
            - name: PACT_BROKER_DATABASE_HOST
              value: sateam-pactcontracts.dev-database
            - name: PACT_BROKER_REPL_URL
              value: sateam-pactcontracts-repl.dev-database
            - name: PACT_BROKER_DATABASE_PORT
              value: "5432"
            - name: PACT_BROKER_DATABASE_NAME
              value:  "pactcontracts"
            - name: PACT_BROKER_DATABASE_USERNAME
              valueFrom:
                secretKeyRef:
                    name: sateam.sateam-pactcontracts
                    key: username
            - name: PACT_BROKER_DATABASE_PASSWORD
              valueFrom:
                secretKeyRef:
                    name: sateam.sateam-pactcontracts
                    key: password

```
--------------------------
Dry run 2: Without specifying custom env names:

Input:

```
postgres:
  teamId: sateam
  dbName: pactcontracts
  owner: sateam
  version: 11  # database version
  size: 2Gi   # database size
  numberOfInstances: 1

```
Output: defaults to existing naming convention
```
 env:
            - name: "PACT_BROKER_PORT"
              value: "9292"
            - name: "PACT_BROKER_PUBLIC_HEARTBEAT"
              value: "true"
            - name: POSTGRES_URL
              value: sateam-pactcontracts.dev-database
            - name: POSTGRES_REPL_URL
              value: sateam-pactcontracts-repl.dev-database
            - name: POSTGRES_PORT
              value: "5432"
            - name: POSTGRES_DBNAME
              value:  "pactcontracts"
            - name: POSTGRES_USERNAME
              valueFrom:
                secretKeyRef:
                    name: sateam.sateam-pactcontracts
                    key: username
            - name: POSTGRES_PASSWORD
              valueFrom:
                secretKeyRef:
                    name: sateam.sateam-pactcontracts
                    key: password
```
