### PR TITLE
fix: updated the node affinity block

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.8
+version: 1.4.9

--- a/charts/service/templates/_affinity.tpl
+++ b/charts/service/templates/_affinity.tpl
@@ -2,17 +2,19 @@
 {{- if .Values.persistentVolume }}
 affinity:
   nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
+    requiredDuringSchedulingRequiredDuringExecution:
       nodeSelectorTerms:
       - matchExpressions:
         - key: px/enabled
-          operator: NotIn
+          operator: In
           values:
-          - "false"
-        - key: worker-type
-          operator: NotIn
+          - "true"
+      - matchExpressions:
+        - key: NodeType
+          operator: In
           values:
-          - jenkins-workers
+          - "storage"
+
 {{- else if .Values.affinity -}}
 {{- with .Values.affinity }}
 affinity:
@@ -21,12 +23,17 @@ affinity:
 {{- else }}
 affinity:
   nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
+    requiredDuringSchedulingRequiredDuringExecution:
       nodeSelectorTerms:
       - matchExpressions:
-        - key: worker-type
-            operator: NotIn
-            values:
-            - jenkins-workers
+        - key: px/enabled
+          operator: In
+          values:
+          - "false"
+      - matchExpressions:
+        - key: NodeType
+          operator: In
+          values:
+          - "general-purpose"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- updated the node affinity block to better support the node labels on the new cluster... we are getting rid of the jenkins-worker node label.