### PR TITLE
Bugfix/plat 338 postgres backup spec error

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.13
+version: 1.4.14

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -20,6 +20,7 @@ metadata:
   namespace: {{ $dbNamespace }}
   labels:
 {{ include "service.commonLabels" . | indent 4 }}
+    cluster-name: {{ $dbClusterName }}
   annotations:
     {{- if .Values.cleanUpIn }}
     janitor/ttl: {{ .Values.cleanUpIn }}
@@ -87,7 +88,7 @@ spec:
       preExecRule: ""
       reclaimPolicy: Retain
       selectors:
-      - cluster-name: {{ $dbClusterName }}
+        cluster-name: {{ $dbClusterName }}
       
 {{- end }}
 {{ end }}


### PR DESCRIPTION
Fixed an error with the spec with how the selector was set.  Also to make sure the backup also gets the postgresql crd resource added the cluster-name to the labels.