### PR TITLE
Feature/plat 337 tolerations

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.12
+version: 1.4.13

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.13
+version: 1.4.15

--- a/charts/service/templates/_affinity.tpl
+++ b/charts/service/templates/_affinity.tpl
@@ -1,5 +1,5 @@
 {{- define "service.affinity" }}
-{{- if .Values.persistentVolume }}
+{{- if or ( .Values.persistentVolume ) ( .Values.postgres) }}
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/service/templates/_tolerations.tpl
+++ b/charts/service/templates/_tolerations.tpl
@@ -1,11 +1,10 @@
 {{- define "service.tolerations" }}
-{{- if .Values.persistentVolume }}
+{{- if or ( .Values.persistentVolume ) ( .Values.postgres ) }}
 tolerations:
 - key: "dedicated"
   operator: "Equal"
   value: "storage"
   effect: "NoSchedule"
-
 {{- else if .Values.tolerations -}}
 {{- with .Values.tolerations }}
 tolerations:

--- a/charts/service/templates/_tolerations.tpl
+++ b/charts/service/templates/_tolerations.tpl
@@ -1,0 +1,15 @@
+{{- define "service.tolerations" }}
+{{- if .Values.persistentVolume }}
+tolerations:
+- key: "dedicated"
+  operator: "Equal"
+  value: "storage"
+  effect: "NoSchedule"
+
+{{- else if .Values.tolerations -}}
+{{- with .Values.tolerations }}
+tolerations:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -130,7 +130,4 @@ spec:
             claimName: {{ .Values.persistentVolume.claimName }}
       {{- end -}}
     {{ include "service.affinity" . | indent 6 }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+    {{ include "service.tolerations" . | indent 6 }}

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -43,14 +43,24 @@ spec:
     version: {{ quote .Values.postgres.version }}
 
   nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: px/enabled
-              operator: NotIn
-              values:
-                - "false"
+  requiredDuringSchedulingIgnoredDuringExecution:
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: px/enabled
+            operator: In
+            values:
+              - "true"
+      - matchExpressions:
+        - key: NodeType
+          operator: In
+          values:
+          - "storage"
 
+  tolerations:
+  - key: "dedicated"
+    operator: "Equal"
+    value: "storage"
+    effect: "NoSchedule"
 
 # Replicated Secret from the {Database Namespace}/{dbOwner Secret}
 ---

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -42,25 +42,10 @@ spec:
   postgresql:
     version: {{ quote .Values.postgres.version }}
 
-  nodeAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-    nodeSelectorTerms:
-      - matchExpressions:
-          - key: px/enabled
-            operator: In
-            values:
-              - "true"
-      - matchExpressions:
-        - key: NodeType
-          operator: In
-          values:
-          - "storage"
+  {{ include "service.affinity" . | indent 2 }}
+  {{ include "service.tolerations" . | indent 2 }}
 
-  tolerations:
-  - key: "dedicated"
-    operator: "Equal"
-    value: "storage"
-    effect: "NoSchedule"
+
 
 # Replicated Secret from the {Database Namespace}/{dbOwner Secret}
 ---

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -202,15 +202,7 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: worker-type
-          operator: NotIn
-          values:
-          - jenkins-workers
+affinity: {}
 
 persistentVolumeClaim: {}
   # This should only be used if a claim does not already exist.  If there is a pre-existing


### PR DESCRIPTION
- This is for setting the POD tolerations for workloads that require persistence storage or creating a postgres db.
- This will help co-locate these workloads better and also not allow workloads that do not need persistence to run on the Portworx storage nodes.