### PR TITLE
Adding a first pass at authz for istio Authorization Policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,19 @@ auth:
     jwks: 'https://chghealthcare.okta.com/oauth2/aus46u1vjfkkTfP7d2p7/v1/keys'
 
 
+# Authz utilizes Istio's built-in route bases authorization bases on the claims that are in the JWT.
+# The current convention only relies on the "groups" claim that the default authorizer
+# implicitly adds to all tokens. That way, the external okta tenant can have a universal way
+# to manage access. Note that currently, this paradigm does not do resource owner or ABAC level
+# access. Please keep dialog close to the SA team for more advanced implementations.
+authz: [] #remove array when uncommenting
+  # - route: '/publicinfo/*'
+  #   groups: ['Everyone']
+  #   verbs: ['GET']
+  # - route: '/divisions/weatherby/*'
+  #   groups: ['SuperAdmins', 'TEST_CONNECT_REP']
+  #   verbs: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']
+
 envs: []
 # - name: ENVIRONMENT
 #   value: production

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.16
+version: 1.4.17

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.17
+version: 1.4.18

--- a/charts/service/templates/istio-policy.yaml
+++ b/charts/service/templates/istio-policy.yaml
@@ -37,6 +37,19 @@ spec:
       app.kubernetes.io/name: {{ include "service.name" . }}
   action: ALLOW
   rules:
+{{- range .Values.authz }}
+  - from:
+    - source:
+        principals: ["*"]
+    to:
+      - operation:
+          methods: {{ .verbs | toJson }}
+          paths: 
+            - {{ .route | quote }}
+    when:
+      - key: request.auth.claims[groups]
+        values: {{ .groups | toJson }}
+{{- end }}
   - from:
     - source:
         requestPrincipals: ["{{ $auth.issuer }}/*","{{ $authGlobal.issuer }}/*"]

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -143,6 +143,19 @@ authGlobal:
     issuer: "https://chghealthcare.okta.com/oauth2/default"
     jwks: "https://chghealthcare.okta.com/oauth2/default/v1/keys"
 
+# Authz utilizes Istio's built-in route bases authorization bases on the claims that are in the JWT.
+# The current convention only relies on the "groups" claim that the default authorizer
+# implicitly adds to all tokens. That way, the external okta tenant can have a universal way
+# to manage access. Note that currently, this paradigm does not do resource owner or ABAC level
+# access. Please keep dialog close to the SA team for more advanced implementations.
+authz: [] #remove array when uncommenting
+  # - route: '/publicinfo/*'
+  #   groups: ['Everyone']
+  #   verbs: ['GET']
+  # - route: '/divisions/weatherby/*'
+  #   groups: ['SuperAdmins', 'TEST_CONNECT_REP']
+  #   verbs: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']
+
 envs: []
 # - name: ENVIRONMENT
 #   value: production

--- a/values-dev.yaml
+++ b/values-dev.yaml
@@ -10,3 +10,11 @@ health:
   readiness:
     path: /readiness
     port: 8080
+
+authz: #remove array when uncommenting
+  - route: '/publicinfo/*'
+    groups: ['Everyone']
+    verbs: ['GET']
+  - route: '/divisions/weatherby/*'
+    groups: ['SuperAdmins', 'TEST_CONNECT_REP']
+    verbs: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']


### PR DESCRIPTION
Auth implementation of the current working concept for sidecar level authz. 
Authz utilizes Istio's built-in route bases authorization bases on the claims that are in the JWT.
The current convention only relies on the "groups" claim that the default authorizer implicitly adds to all tokens. 
That way, the external okta tenant can have a universal way to manage access. Note that currently, this paradigm does not do resource owner or ABAC level access. Services will still have to embed those types Authz into their application code. We are currently investigating other solutions for that style of access as well.