### PR TITLE
feat: add CronJob to the service chart

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.22
+version: 1.4.23

--- a/charts/service/templates/cronjob.yaml
+++ b/charts/service/templates/cronjob.yaml
@@ -1,0 +1,76 @@
+{{ $root := . }}
+{{ range $index, $cronjob := $root.Values.cronjobs }}
+{{ $hookAnnotations := index $cronjob.annotations "helm.sh/hook" }}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "service.fullname" $root }}-cronjob-{{ $index }}
+  labels:
+{{ include "service.commonLabels" $root | indent 4 }}
+  annotations:
+    {{ range $key, $val := $cronjob.annotations }}
+    {{- $key }}: {{ $val }}
+    {{ end }}
+spec:
+  schedule: "{{ $cronjob.schedule }}"
+  {{- if $cronjob.concurrencyPolicy }}
+  concurrencyPolicy: {{ $cronjob.concurrencyPolicy }}
+  {{- end }}
+  {{- if $cronjob.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ $cronjob.successfulJobsHistoryLimit }}
+  {{- end }}
+  {{- if $cronjob.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ $cronjob.failedJobsHistoryLimit }}
+  {{- end }}
+  {{- if $cronjob.suspend }}
+  suspend: {{ $cronjob.suspend }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ $cronjob.containerName }}
+            image: {{ $cronjob.image }}
+            command: {{ range $cronjob.command }}
+            - {{ . | quote }}{{ end }}
+            env:
+              {{- range $root.Values.envs }}
+                - name: {{ .name | quote }}
+                  value: {{ .value | quote }}
+              {{- end }}
+              {{- range $root.Values.configMapKeys }}
+                - name: {{ .name | quote}}
+                  valueFrom:
+                    configMapKeyRef:
+                        name: {{ .keymap | quote }}
+                        key: {{ .key | quote }}
+              {{- end }}
+              {{- range $root.Values.secretKeys }}
+                - name: {{ .name | quote }}
+                  valueFrom:
+                    secretKeyRef:
+                        name: {{ .secret | quote }}
+                        key: {{ .key | quote }}
+              {{- end }}
+              {{- range .envs }}
+                - name: {{ .name | quote }}
+                  value: {{ .value | quote }}
+              {{- end }}
+            envFrom:
+              {{- if $root.Values.pullVaultSecrets }}{{- if not (contains "pre-install" $hookAnnotations) }}{{- if not (contains "pre-upgrade" $hookAnnotations) }}
+              - secretRef:
+                  name: {{ include "service.fullname" $root | quote }}
+              {{- end }}{{- end }}{{- end }}
+              {{- range $root.Values.secretRefs }}
+              - secretRef:
+                  name: {{ . | quote }}
+              {{- end }}
+              {{- range $root.Values.configMaps }}
+              - configMapRef:
+                  name: {{ . | quote }}
+              {{- end }}
+          restartPolicy: OnFailure
+
+{{ end }}

--- a/charts/service/templates/cronjob.yaml
+++ b/charts/service/templates/cronjob.yaml
@@ -29,6 +29,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            "sidecar.istio.io/inject": "false"
         spec:
           containers:
           - name: {{ $cronjob.containerName }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -151,7 +151,8 @@ authGlobal:
 # implicitly adds to all tokens. That way, the external okta tenant can have a universal way
 # to manage access. Note that currently, this paradigm does not do resource owner or ABAC level
 # access. Please keep dialog close to the SA team for more advanced implementations.
-authz: [] #remove array when uncommenting
+authz:
+  [] #remove array when uncommenting
   # - route: '/publicinfo/*'
   #   groups: ['Everyone']
   #   verbs: ['GET']
@@ -302,3 +303,16 @@ cleanUpIn: 48h
 # It will also change the dns name you need to go through to reach your service,
 # from myservice.prod.chgapi.com (aka myservice.prod.platform.aws.chgit.com) to myservice.prod.chgapi.net
 #private: true
+
+# Run scheduled jobs via the cronjobs template
+# cronjobs:
+#   - containerName: "chg-leads-intake-api-ping-test"
+#     schedule: "*/2 * * * *"
+#     successfulJobsHistoryLimit: 1
+#     failedJobsHistoryLimit: 2
+#     concurrencyPolicy: Replace
+#     # image is set in helm upgrade command
+#     command: ["npm", "run", "test:ping"]
+#     annotations:
+#       "helm.sh/hook": post-install,post-upgrade
+#       "helm.sh/hook-delete-policy": before-hook-creation


### PR DESCRIPTION
This adds cronjob to the service template. On LTC we want to use this to hit our services every few minutes so we can fire an alert if the service cannot be reached. This will catch things like a problem with our Istio setup, authentication issues, expired SSL certs, etc.