### PR TITLE
redis needs truncated to 46 because of the pod labels that are genera…

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.25
+version: 1.4.26

--- a/charts/service/templates/_helpers.tpl
+++ b/charts/service/templates/_helpers.tpl
@@ -27,11 +27,13 @@ If release name contains chart name it will be used as a full name.
 {{- printf "%s-%s" .Values.feature .Values.project | trunc 63 | trimPrefix "-" | trimSuffix "-" -}}
 {{- end -}}
 {{/*
-The redis operator prepends 'redis-' and appends '-headless' to the service names automatically,
-so for redis we need to truncate down to 48 characters (15 + 48 = 63) as the maximum length 
+The redis operator prepends 'redis-' and appends a dash plus 10 random characters to 
+pod labels and service names (but -headless for service names) automatically.
+The label is formatted like this (6 characters + 46 characters + 11 characters) = 63 characters:
+redis-<>-7f555fc786
 */}}
 {{- define "service.redisFullname" -}}
-{{- printf "%s-%s" .Values.feature .Values.project | trunc 48 | trimPrefix "-" | trimSuffix "-" -}}
+{{- printf "%s-%s" .Values.feature .Values.project | trunc 46 | trimPrefix "-" | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
…ted by the operator

Tested this again by doing the following:
- Make changes to values.yaml to enable redis
- Run command: `helm template ./ --set 'feature=aadsfafdsafdsafdassdfasfdafdsafdsfdsafdafda,project=someprojecthere' --namespace=feature`
- Grab the redis section, threw it into a file, and run `cat test.yaml | kubectl apply -f -n`
- Run `kubectl get pods -n feature-database | grep aads` until the pods are up, and verify they are running successfully with 3 replicas.
- Run `kubectl get service -n feature-database | grep aads` and verify the service was still created successfully.