### PR TITLE
Feature/postgres backup and restore

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.27
+version: 1.4.28

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -86,9 +86,6 @@ spec:
       selectors:
         cluster-name: {{ $dbClusterName }}
 
-{{- end }}
-
-{{- if or (eq .Values.environment "stage") (eq .Values.environment "prod")}}
 # Helm Job hook on pre-delete backup postgres db cluster
 ---
 apiVersion: stork.libopenstorage.org/v1alpha1
@@ -104,18 +101,14 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded    
   spec:
     backupLocation: s3backup-default
-    namespaces:
-    - {{ $dbNamespace }}
-   reclaimPolicy: Delete
-   selectors:
-     cluster-name: $dbClusterName
-   preExecRule:
-   postExecRule:
+    reclaimPolicy: Delete
+    selectors:
+      cluster-name: {{ $dbClusterName }}
+    preExecRule:
+    postExecRule:
+{{- end }} 
 
-{{- end }}
-
-{{- if or (eq .Values.environment "stage") (eq .Values.environment "prod") }}
-{{- if .Values.postgres.restoredb }}
+{{- if and (or (eq .Values.environment "stage") (eq .Values.environment "prod")) (.Values.postgres.restoredb) }}
 # Helm Job hook on pre-install to restore postgres db cluster from the last backup
 ---
 apiVersion: stork.libopenstorage.org/v1alpha1
@@ -133,8 +126,7 @@ metadata:
     backupName: {{ .Values.postgres.restoredb }}
     backupLocation: s3backup-default
     namespaceMapping:
-        {{ $dbNamespace }}: {{ $dbNamespace }}   
-        
-{{- end }}
-{{- end }}
-{{ end }}
+      stage-database: stage-database
+{{- end}}
+         
+{{ end }}    

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -126,7 +126,7 @@ metadata:
     backupName: {{ .Values.postgres.restoredb }}
     backupLocation: s3backup-default
     namespaceMapping:
-      stage-database: stage-database
+      {{ $dbNamespace }}: {{ $dbNamespace }}
 {{- end}}
          
 {{ end }}    

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -106,27 +106,5 @@ metadata:
       cluster-name: {{ $dbClusterName }}
     preExecRule:
     postExecRule:
-{{- end }} 
-
-{{- if and (or (eq .Values.environment "stage") (eq .Values.environment "prod")) (.Values.postgres.restoredb) }}
-# Helm Job hook on pre-install to restore postgres db cluster from the last backup
----
-apiVersion: stork.libopenstorage.org/v1alpha1
-kind: ApplicationRestore
-metadata:
-  name: {{ .Values.postgres.restoredb }}
-  namespace: {{ $dbNamespace }}
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded    
-  spec:
-    backupName: {{ .Values.postgres.restoredb }}
-    backupLocation: s3backup-default
-    namespaceMapping:
-      {{ $dbNamespace }}: {{ $dbNamespace }}
-{{- end}}
-         
+{{- end }}          
 {{ end }}    

--- a/charts/service/templates/postgres-db.yaml
+++ b/charts/service/templates/postgres-db.yaml
@@ -85,6 +85,56 @@ spec:
       reclaimPolicy: Retain
       selectors:
         cluster-name: {{ $dbClusterName }}
-      
+
+{{- end }}
+
+{{- if or (eq .Values.environment "stage") (eq .Values.environment "prod")}}
+# Helm Job hook on pre-delete backup postgres db cluster
+---
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: ApplicationBackup
+metadata:
+  name: {{ printf "%s-backup" $dbClusterName }}
+  namespace: {{ $dbNamespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded    
+  spec:
+    backupLocation: s3backup-default
+    namespaces:
+    - {{ $dbNamespace }}
+   reclaimPolicy: Delete
+   selectors:
+     cluster-name: $dbClusterName
+   preExecRule:
+   postExecRule:
+
+{{- end }}
+
+{{- if or (eq .Values.environment "stage") (eq .Values.environment "prod") }}
+{{- if .Values.postgres.restoredb }}
+# Helm Job hook on pre-install to restore postgres db cluster from the last backup
+---
+apiVersion: stork.libopenstorage.org/v1alpha1
+kind: ApplicationRestore
+metadata:
+  name: {{ .Values.postgres.restoredb }}
+  namespace: {{ $dbNamespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded    
+  spec:
+    backupName: {{ .Values.postgres.restoredb }}
+    backupLocation: s3backup-default
+    namespaceMapping:
+        {{ $dbNamespace }}: {{ $dbNamespace }}   
+        
+{{- end }}
 {{- end }}
 {{ end }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 # [REQUIRED]
 # This is a required field
 # options [development, stage, production]
-environment: "development"
+environment: "stage"
 
 # Database Type. Default to no database.
 #
@@ -104,13 +104,14 @@ serviceAccountName:
 #   replicationFactor: 2
 #   envKey: SOME_TOPIC_NAME_DEAD_LETTER
 
-# postgres:
-#  teamId: sa
-#  dbName: demodb
-#  owner: saadmin
-#  version: 11  # database version
-#  size: 1Gi   # database size
-#  numberOfInstances: 2 # number of postgres instances 1 - master 2..replica
+postgres:
+  teamId: doggy
+  dbName: appcatlog
+  owner: saowner
+  version: 11  # database version
+  size: 1Gi   # database size
+  numberOfInstances: 1
+  restoredb: mydb-name-is-123-222:121
 
 # The default values here are:
 authEnabled: false

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -111,7 +111,7 @@ postgres:
   version: 11  # database version
   size: 1Gi   # database size
   numberOfInstances: 1
-  restoredb: mydb-name-is-123-222:121
+  restoredb: hello
 
 # The default values here are:
 authEnabled: false

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -105,13 +105,13 @@ serviceAccountName:
 #   envKey: SOME_TOPIC_NAME_DEAD_LETTER
 
 postgres:
-  teamId: doggy
+  teamId: sateam
   dbName: appcatlog
   owner: saowner
   version: 11  # database version
   size: 1Gi   # database size
   numberOfInstances: 1
-  restoredb: hello
+  restoredb: sateam-appcatlog-daily-backup-daily-2021-05-23-233000
 
 # The default values here are:
 authEnabled: false

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 # [REQUIRED]
 # This is a required field
 # options [development, stage, production]
-environment: "stage"
+environment: "development"
 
 # Database Type. Default to no database.
 #
@@ -104,14 +104,13 @@ serviceAccountName:
 #   replicationFactor: 2
 #   envKey: SOME_TOPIC_NAME_DEAD_LETTER
 
-postgres:
-  teamId: sateam
-  dbName: appcatlog
-  owner: saowner
-  version: 11  # database version
-  size: 1Gi   # database size
-  numberOfInstances: 1
-  restoredb: sateam-appcatlog-daily-backup-daily-2021-05-23-233000
+#postgres:
+#  teamId: sateam
+#  dbName: appcatlog
+#  owner: saowner
+#  version: 11  # database version
+#  size: 1Gi   # database size
+#  numberOfInstances: 1
 
 # The default values here are:
 authEnabled: false


### PR DESCRIPTION
This creates a backup of the postgres db when user does a helm delete/uninstall of an app that has a postgresdb. cluster. 

The following is the output of the dry run.   These yamls are based on my poc https://chghealthcare.atlassian.net/wiki/spaces/IEA/pages/765820992/Part+1+How+to+manually+backup+a+Postgresql+database.

It generates the ApplicationBackup yaml.  I have yet to try to it on stage.

```
# Source: service/templates/postgres-db.yaml
apiVersion: stork.libopenstorage.org/v1alpha1
kind: ApplicationBackup
metadata:
  name: sateam-appcatlog-backup
  namespace: stage-database
  annotations:
    # This is what defines this resource as a hook. Without this line, the
    # job is considered part of the release.
    "helm.sh/hook": pre-delete
    "helm.sh/hook-weight": "-5"
    "helm.sh/hook-delete-policy": hook-succeeded    
  spec:
    backupLocation: s3backup-default
    reclaimPolicy: Delete
    selectors:
      cluster-name: sateam-appcatlog
    preExecRule:
    postExecRule:
```