### PR TITLE
Removed Chart Version From commonLabels

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.28
+version: 1.4.29

--- a/charts/service/templates/_helpers.tpl
+++ b/charts/service/templates/_helpers.tpl
@@ -44,7 +44,6 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 {{- define "service.commonLabels" -}}
 app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -87,7 +87,7 @@ istiogateway:
 istioAllowedPaths: []
 istioAllowedMethods: []
 
-# if you need to overight the privalage of one of your deployments
+# if you need to overwrite the privilege of one of your deployments
 serviceAccountName:
 
 # Example of how to specify kafka topics to be created


### PR DESCRIPTION
This PR is to fix an issue where Redis resources fail to get managed across chart versions upgrades. The Redis operator uses the labels for the CRD as the selectors for the resource. The common labels include the helm chart version, which can change across deploys. This PR will remove the chart version from the common labels.