### PR TITLE
feat: added the node affinity block for job and cronjob templates

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.31
+version: 1.4.32

--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.30
+version: 1.4.31

--- a/charts/service/templates/cronjob.yaml
+++ b/charts/service/templates/cronjob.yaml
@@ -78,5 +78,20 @@ spec:
                   name: {{ . | quote }}
               {{- end }}
           restartPolicy: OnFailure
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: px/enabled
+                    operator: In
+                    values:
+                    - "false"
+                - matchExpressions:
+                  - key: NodeType
+                    operator: In
+                    values:
+                    - "general-purpose"
+
 
 {{ end }}

--- a/charts/service/templates/job.yaml
+++ b/charts/service/templates/job.yaml
@@ -70,5 +70,18 @@ spec:
               name: {{ . | quote }}
           {{- end }}
       restartPolicy: Never
-
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: In
+                values:
+                - "false"
+            - matchExpressions:
+              - key: NodeType
+                operator: In
+                values:
+                - "general-purpose"
 {{ end }}


### PR DESCRIPTION
- Adding the nodeAffinity to the job and cronjob temp[lates will force these to run on non Portworx backed nodes.