### PR TITLE
add support for hostAliases

### DIFF
--- a/charts/service/Chart.yaml
+++ b/charts/service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for CHG Platform. Using Istio for ingress.
 name: service
-version: 1.4.32
+version: 1.4.33

--- a/charts/service/templates/deployment.yaml
+++ b/charts/service/templates/deployment.yaml
@@ -39,6 +39,16 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
       automountServiceAccountToken: true
       {{- end }}
+      {{- if .Values.hostAliases}}
+      hostAliases:
+      {{- range .Values.hostAliases}}
+      - ip: {{ .ip | quote}}
+        hostnames:
+        {{- range .hostnames}}
+        - {{. | quote}}
+        {{- end}}
+      {{- end}}
+      {{- end}}
       {{- if .Values.initContainer }}
       initContainers:
       - name: {{ .Values.initContainer.name }}

--- a/charts/service/values.yaml
+++ b/charts/service/values.yaml
@@ -287,6 +287,18 @@ cleanUpIn: 48h
 #  numberOfInstances: 1
 #  version: 11
 
+# For adding mapping to /etc/hosts of the service
+# More information here: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/
+#hostAliases:
+#- ip: "127.0.0.1"
+#  hostnames:
+#  - "foo.local"
+#  - "bar.local"
+#- ip: "10.1.2.3"
+#  hostnames:
+#  - "foo.remote"
+#  - "bar.remote"
+
 # For Overriding the default deployment strategy
 ### For a Rolling update strategy (this is the default behavior but can override the max/min options
 #strategy:


### PR DESCRIPTION
This will allow hostAliases to be defined in the values.yaml file that will be put into /etc/hosts of the service.  This will act similar to the service endpoints, but will allow us to use the real hostnames of the on-prem services thus relieving a lot of issues with ssl certificates.

More info on hostAliases can be found here: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/

I have also tested this change with a service and the outcome is as expected.